### PR TITLE
Add creative playground section showcasing interactive mini apps

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -2,6 +2,7 @@ import Hero from '@/components/sections/hero';
 import About from '@/components/sections/about';
 import Experience from '@/components/sections/experience';
 import Projects from '@/components/sections/projects';
+import Playground from '@/components/sections/playground';
 import Skills from '@/components/sections/skills';
 import Contact from '@/components/sections/contact';
 
@@ -11,6 +12,7 @@ const Page = () => (
     <About />
     <Experience />
     <Projects />
+    <Playground />
     <Skills />
     <Contact />
   </>

--- a/components/experiments/gradient-playground.tsx
+++ b/components/experiments/gradient-playground.tsx
@@ -1,0 +1,111 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+import { motion } from 'framer-motion';
+
+const randomColor = () =>
+  `#${Math.floor(Math.random() * 0xffffff)
+    .toString(16)
+    .padStart(6, '0')}`;
+
+const GradientPlayground = () => {
+  const [colorA, setColorA] = useState('#4338ca');
+  const [colorB, setColorB] = useState('#ec4899');
+  const [angle, setAngle] = useState(135);
+  const [copied, setCopied] = useState(false);
+
+  const gradient = useMemo(() => `linear-gradient(${angle}deg, ${colorA}, ${colorB})`, [angle, colorA, colorB]);
+
+  const handleShuffle = () => {
+    setColorA(randomColor());
+    setColorB(randomColor());
+    setCopied(false);
+  };
+
+  const handleCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(
+        `background: ${gradient};
+background-image: ${gradient};`
+      );
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1600);
+    } catch (error) {
+      console.error('Kon gradient niet kopiëren', error);
+    }
+  };
+
+  return (
+    <div className="flex h-full flex-col justify-between gap-6 rounded-2xl border border-white/10 bg-white/[0.04] p-5 shadow-lg">
+      <motion.div
+        className="relative flex flex-1 items-center justify-center overflow-hidden rounded-2xl border border-white/5"
+        style={{ backgroundImage: gradient }}
+        initial={{ opacity: 0.4, scale: 0.95 }}
+        animate={{ opacity: 1, scale: 1 }}
+        transition={{ duration: 0.6, ease: 'easeOut' }}
+      >
+        <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_20%_20%,rgba(255,255,255,0.35),transparent_60%)] opacity-60" />
+        <div className="relative mx-auto w-full max-w-xs rounded-2xl bg-background/80 p-4 text-center text-sm text-muted-foreground shadow-lg">
+          <p className="font-semibold text-foreground">Gradient vibes</p>
+          <p className="mt-2 text-xs leading-relaxed">
+            Pas de hoek aan met de slider of gooi een nieuwe combinatie met de shuffle-knop. Klaar? Kopieer de CSS direct.
+          </p>
+        </div>
+      </motion.div>
+      <div className="grid gap-4 text-sm">
+        <div className="grid grid-cols-2 gap-3 text-muted-foreground">
+          <label className="flex items-center justify-between rounded-xl border border-white/10 bg-background/60 px-4 py-3">
+            <span className="text-xs uppercase tracking-[0.25em] text-highlight">kleur 1</span>
+            <input
+              type="color"
+              value={colorA}
+              onChange={(event) => setColorA(event.target.value)}
+              className="h-8 w-12 cursor-pointer rounded border border-white/20 bg-transparent p-0"
+              aria-label="Eerste kleur"
+            />
+          </label>
+          <label className="flex items-center justify-between rounded-xl border border-white/10 bg-background/60 px-4 py-3">
+            <span className="text-xs uppercase tracking-[0.25em] text-highlight">kleur 2</span>
+            <input
+              type="color"
+              value={colorB}
+              onChange={(event) => setColorB(event.target.value)}
+              className="h-8 w-12 cursor-pointer rounded border border-white/20 bg-transparent p-0"
+              aria-label="Tweede kleur"
+            />
+          </label>
+        </div>
+        <label className="flex flex-col gap-2 text-xs uppercase tracking-[0.25em] text-highlight">
+          Hoek
+          <input
+            type="range"
+            min={0}
+            max={360}
+            value={angle}
+            onChange={(event) => setAngle(Number(event.target.value))}
+            className="h-2 w-full cursor-pointer appearance-none rounded-full bg-white/10 accent-highlight"
+          />
+          <span className="text-[0.7rem] text-muted-foreground">{angle}&deg;</span>
+        </label>
+        <div className="flex flex-wrap gap-2">
+          <button
+            type="button"
+            onClick={handleShuffle}
+            className="flex flex-1 items-center justify-center gap-2 rounded-full border border-white/20 bg-white/10 px-4 py-2 text-xs font-semibold text-foreground transition hover:border-highlight/70 hover:bg-highlight/20"
+          >
+            Shuffle
+          </button>
+          <button
+            type="button"
+            onClick={handleCopy}
+            className="flex flex-1 items-center justify-center gap-2 rounded-full border border-white/20 bg-gradient-to-r from-highlight/80 via-highlight to-accent px-4 py-2 text-xs font-semibold text-background transition hover:brightness-105"
+          >
+            {copied ? 'Gekopieerd!' : 'Kopieer CSS'}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default GradientPlayground;

--- a/components/experiments/lofi-focus-timer.tsx
+++ b/components/experiments/lofi-focus-timer.tsx
@@ -1,0 +1,146 @@
+'use client';
+
+import { useEffect, useMemo, useState } from 'react';
+
+const formatTime = (seconds: number) => {
+  const minutes = Math.floor(seconds / 60)
+    .toString()
+    .padStart(2, '0');
+  const remainder = Math.floor(seconds % 60)
+    .toString()
+    .padStart(2, '0');
+  return `${minutes}:${remainder}`;
+};
+
+const LoFiFocusTimer = () => {
+  const [mode, setMode] = useState<'focus' | 'break'>('focus');
+  const [focusMinutes, setFocusMinutes] = useState(25);
+  const [breakMinutes, setBreakMinutes] = useState(5);
+  const [timeLeft, setTimeLeft] = useState(focusMinutes * 60);
+  const [isRunning, setIsRunning] = useState(false);
+
+  const durations = useMemo(
+    () => ({ focus: focusMinutes * 60, break: breakMinutes * 60 }),
+    [focusMinutes, breakMinutes]
+  );
+
+  useEffect(() => {
+    if (!isRunning) {
+      setTimeLeft(durations[mode]);
+    }
+  }, [durations, mode, isRunning]);
+
+  useEffect(() => {
+    if (!isRunning) {
+      return undefined;
+    }
+
+    const interval = setInterval(() => {
+      setTimeLeft((current) => {
+        if (current <= 1) {
+          const nextMode = mode === 'focus' ? 'break' : 'focus';
+          const nextDuration = durations[nextMode];
+          setMode(nextMode);
+          return nextDuration;
+        }
+
+        return current - 1;
+      });
+    }, 1000);
+
+    return () => clearInterval(interval);
+  }, [isRunning, mode, durations]);
+
+  const activeDuration = durations[mode] || 1;
+  const progress = Math.max(0, Math.min(1, 1 - timeLeft / activeDuration));
+
+  return (
+    <div className="flex h-full flex-col gap-5 rounded-2xl border border-white/10 bg-white/[0.04] p-5 shadow-lg">
+      <div className="space-y-2 text-center">
+        <p className="text-xs uppercase tracking-[0.4em] text-highlight">{mode === 'focus' ? 'focus' : 'break'}</p>
+        <p className="font-display text-4xl font-semibold text-foreground">{formatTime(timeLeft)}</p>
+        <p className="text-xs text-muted-foreground">
+          Stel je sessies af op jouw vibe en laat de timer de rest doen. Wissel automatisch tussen focus en pauze.
+        </p>
+      </div>
+      <div className="relative h-2 w-full overflow-hidden rounded-full bg-white/10">
+        <div
+          className="absolute inset-y-0 left-0 rounded-full bg-gradient-to-r from-highlight via-highlight to-accent"
+          style={{ width: `${progress * 100}%` }}
+        />
+      </div>
+      <div className="grid gap-4 text-sm text-muted-foreground md:grid-cols-2">
+        <label className="flex flex-col gap-1 rounded-xl border border-white/10 bg-background/60 p-4">
+          <span className="text-xs uppercase tracking-[0.25em] text-highlight">focus minuten</span>
+          <input
+            type="range"
+            min={10}
+            max={50}
+            step={5}
+            value={focusMinutes}
+            onChange={(event) => {
+              const value = Number(event.target.value);
+              setFocusMinutes(value);
+              if (!isRunning && mode === 'focus') {
+                setTimeLeft(value * 60);
+              }
+            }}
+            className="h-2 w-full cursor-pointer appearance-none rounded-full bg-white/10 accent-highlight"
+          />
+          <span className="text-xs text-foreground">{focusMinutes} minuten</span>
+        </label>
+        <label className="flex flex-col gap-1 rounded-xl border border-white/10 bg-background/60 p-4">
+          <span className="text-xs uppercase tracking-[0.25em] text-highlight">pauze minuten</span>
+          <input
+            type="range"
+            min={3}
+            max={15}
+            step={1}
+            value={breakMinutes}
+            onChange={(event) => {
+              const value = Number(event.target.value);
+              setBreakMinutes(value);
+              if (!isRunning && mode === 'break') {
+                setTimeLeft(value * 60);
+              }
+            }}
+            className="h-2 w-full cursor-pointer appearance-none rounded-full bg-white/10 accent-highlight"
+          />
+          <span className="text-xs text-foreground">{breakMinutes} minuten</span>
+        </label>
+      </div>
+      <div className="flex flex-wrap gap-2 text-xs font-semibold">
+        <button
+          type="button"
+          onClick={() => {
+            const nextMode = mode === 'focus' ? 'break' : 'focus';
+            setMode(nextMode);
+            setTimeLeft(durations[nextMode]);
+          }}
+          className="flex flex-1 items-center justify-center gap-2 rounded-full border border-white/20 bg-white/10 px-4 py-2 text-foreground transition hover:border-highlight/70 hover:bg-highlight/20"
+        >
+          Wissel modus
+        </button>
+        <button
+          type="button"
+          onClick={() => setIsRunning((current) => !current)}
+          className="flex flex-1 items-center justify-center gap-2 rounded-full border border-white/20 bg-gradient-to-r from-highlight/80 via-highlight to-accent px-4 py-2 text-background transition hover:brightness-105"
+        >
+          {isRunning ? 'Pauzeer' : 'Start'}
+        </button>
+        <button
+          type="button"
+          onClick={() => {
+            setIsRunning(false);
+            setTimeLeft(durations[mode]);
+          }}
+          className="flex flex-1 items-center justify-center gap-2 rounded-full border border-white/20 bg-white/10 px-4 py-2 text-foreground transition hover:border-highlight/70 hover:bg-highlight/20"
+        >
+          Reset
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default LoFiFocusTimer;

--- a/components/experiments/moodboard-mixer.tsx
+++ b/components/experiments/moodboard-mixer.tsx
@@ -1,0 +1,170 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+import { motion } from 'framer-motion';
+
+type Mood = {
+  id: 'chill' | 'energy' | 'adventure';
+  label: string;
+  description: string;
+  palettes: Array<{
+    name: string;
+    emoji: string;
+    colors: [string, string, string];
+    prompt: string;
+  }>;
+};
+
+const moods: Mood[] = [
+  {
+    id: 'chill',
+    label: 'Chill',
+    description: 'Zachte gradients en warme tonen voor avondcoders met lo-fi beats.',
+    palettes: [
+      {
+        name: 'Night Drive',
+        emoji: '🌌🚗',
+        colors: ['#1d1b4f', '#5142a6', '#f8b4d9'],
+        prompt: 'Maak een dashboard dat voelt als een nachtelijke autorit met neonlichten.',
+      },
+      {
+        name: 'Coffee Corner',
+        emoji: '☕️📚',
+        colors: ['#281a1b', '#6d4c41', '#fcd8b6'],
+        prompt: 'Ontwerp een notitie-app die ruikt naar versgemalen koffie.',
+      },
+      {
+        name: 'Serene Synth',
+        emoji: '🎛️🌧️',
+        colors: ['#112031', '#385b73', '#9ec3d5'],
+        prompt: 'Codeer een synth-interface die klinkt als regen op het raam.',
+      },
+    ],
+  },
+  {
+    id: 'energy',
+    label: 'Energy',
+    description: 'Felle kleuren voor ideeën die nét even harder knallen.',
+    palettes: [
+      {
+        name: 'Electric Bloom',
+        emoji: '⚡️🌺',
+        colors: ['#240046', '#7b2cbf', '#ff6f91'],
+        prompt: 'Bedenk een landing page voor een creatieve hackathon bij zonsopkomst.',
+      },
+      {
+        name: 'Laser Arcade',
+        emoji: '🕹️🌈',
+        colors: ['#001845', '#0466c8', '#ff4d6d'],
+        prompt: 'Schets een multiplayer-lobby met arcade vibes en pastel lasers.',
+      },
+      {
+        name: 'Solar Disco',
+        emoji: '🪩☀️',
+        colors: ['#582f0e', '#ffb347', '#ffe156'],
+        prompt: 'Ontwerp een micro-app die de eerste zonnestralen viert.',
+      },
+    ],
+  },
+  {
+    id: 'adventure',
+    label: 'Adventure',
+    description: 'Luchtige combinaties die ruiken naar buitenspelen en roadtrips.',
+    palettes: [
+      {
+        name: 'Cabin Radio',
+        emoji: '🏕️📻',
+        colors: ['#0b3d20', '#3a5a40', '#b6c454'],
+        prompt: 'Visualiseer een radio-interface voor verhalen rond een kampvuur.',
+      },
+      {
+        name: 'Polaroid Trail',
+        emoji: '📸🗺️',
+        colors: ['#1f2a44', '#f5b971', '#f9dec9'],
+        prompt: 'Ontwerp een gallery die voelt als een stapel verse polaroids.',
+      },
+      {
+        name: 'Wander Tunes',
+        emoji: '🚐🎵',
+        colors: ['#0f4c5c', '#56a3a6', '#ffe45e'],
+        prompt: 'Bouw een playlist-widget voor muziek onderweg langs de kust.',
+      },
+    ],
+  },
+];
+
+const MoodboardMixer = () => {
+  const [activeMoodId, setActiveMoodId] = useState<Mood['id']>('chill');
+  const [index, setIndex] = useState(0);
+
+  const activeMood = useMemo(() => moods.find((mood) => mood.id === activeMoodId) ?? moods[0], [activeMoodId]);
+  const palette = activeMood.palettes[index % activeMood.palettes.length];
+
+  const gradient = useMemo(
+    () => `linear-gradient(135deg, ${palette.colors[0]}, ${palette.colors[1]}, ${palette.colors[2]})`,
+    [palette]
+  );
+
+  return (
+    <div className="flex h-full flex-col gap-5 rounded-2xl border border-white/10 bg-white/[0.04] p-5 shadow-lg">
+      <div className="flex flex-wrap gap-2">
+        {moods.map((mood) => {
+          const isActive = mood.id === activeMoodId;
+          return (
+            <button
+              key={mood.id}
+              type="button"
+              onClick={() => {
+                setActiveMoodId(mood.id);
+                setIndex(0);
+              }}
+              className={`rounded-full px-4 py-2 text-xs font-semibold transition ${
+                isActive
+                  ? 'border border-white/20 bg-gradient-to-r from-highlight/80 via-highlight to-accent text-background shadow-glow'
+                  : 'border border-white/15 bg-white/5 text-foreground hover:border-highlight/70 hover:bg-highlight/20'
+              }`}
+            >
+              {mood.label}
+            </button>
+          );
+        })}
+      </div>
+      <motion.div
+        key={palette.name}
+        className="relative flex flex-1 flex-col justify-between overflow-hidden rounded-2xl border border-white/10 p-6 text-foreground"
+        style={{ background: gradient }}
+        initial={{ opacity: 0.6, y: 12 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ duration: 0.6, ease: 'easeOut' }}
+      >
+        <div className="absolute inset-0 bg-[radial-gradient(circle_at_80%_0%,rgba(255,255,255,0.4),transparent_45%)]" aria-hidden />
+        <div className="relative z-10 space-y-4">
+          <p className="text-xs uppercase tracking-[0.3em] text-white/80">{activeMood.label}</p>
+          <h3 className="font-display text-2xl font-semibold text-white drop-shadow">{palette.name}</h3>
+          <p className="text-lg">{palette.emoji}</p>
+          <p className="max-w-sm text-sm text-white/90">{palette.prompt}</p>
+        </div>
+        <div className="relative z-10 mt-6 flex flex-wrap items-center gap-3 text-xs text-white/80">
+          {palette.colors.map((color) => (
+            <div key={color} className="flex items-center gap-2 rounded-full bg-white/15 px-4 py-2 shadow">
+              <span className="h-4 w-4 rounded-full border border-white/50" style={{ backgroundColor: color }} />
+              <span className="font-mono uppercase tracking-[0.2em]">{color.replace('#', '')}</span>
+            </div>
+          ))}
+        </div>
+      </motion.div>
+      <div className="flex flex-wrap items-center justify-between gap-3 text-sm text-muted-foreground">
+        <p className="flex-1 text-xs sm:text-sm">{activeMood.description}</p>
+        <button
+          type="button"
+          onClick={() => setIndex((current) => (current + 1) % activeMood.palettes.length)}
+          className="inline-flex items-center gap-2 rounded-full border border-white/20 bg-white/10 px-4 py-2 text-xs font-semibold text-foreground transition hover:border-highlight/70 hover:bg-highlight/20"
+        >
+          Volgende idee
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default MoodboardMixer;

--- a/components/sections/playground.tsx
+++ b/components/sections/playground.tsx
@@ -1,0 +1,140 @@
+'use client';
+
+import { type ComponentType, useEffect, useMemo, useState } from 'react';
+import { AnimatePresence, motion } from 'framer-motion';
+import GradientPlayground from '@/components/experiments/gradient-playground';
+import LoFiFocusTimer from '@/components/experiments/lofi-focus-timer';
+import MoodboardMixer from '@/components/experiments/moodboard-mixer';
+import FadeIn from '@/components/motion/fade-in';
+import SectionHeading from '@/components/ui/section-heading';
+import ShinyButton from '@/components/ui/shiny-button';
+import { experiments } from '@/data/content';
+import { cn } from '@/lib/utils';
+
+const experimentComponents: Record<string, ComponentType> = {
+  'gradient-playground': GradientPlayground,
+  'lofi-focus-timer': LoFiFocusTimer,
+  'moodboard-mixer': MoodboardMixer,
+};
+
+const ExperimentCard = ({
+  experiment,
+  isActive,
+  onSelect,
+}: {
+  experiment: (typeof experiments)[number];
+  isActive: boolean;
+  onSelect: () => void;
+}) => (
+  <motion.button
+    type="button"
+    onClick={onSelect}
+    whileHover={{ y: -4 }}
+    whileTap={{ scale: 0.98 }}
+    aria-pressed={isActive}
+    className={cn(
+      'group flex h-full flex-col gap-4 rounded-3xl border border-white/10 bg-background/70 p-6 text-left transition',
+      isActive
+        ? 'border-highlight/60 bg-white/10 shadow-xl ring-2 ring-highlight/50'
+        : 'hover:border-highlight/40 hover:bg-white/5'
+    )}
+  >
+    <div className="flex items-center justify-between text-xs uppercase tracking-[0.3em] text-muted-foreground">
+      <span>Mini app</span>
+      <span>{experiment.stack.join(' · ')}</span>
+    </div>
+    <div className="space-y-3">
+      <h3 className="font-display text-lg font-semibold text-foreground">{experiment.title}</h3>
+      <p className="text-sm text-muted-foreground">{experiment.summary}</p>
+    </div>
+    <div className="mt-auto flex items-center justify-between text-xs font-semibold text-highlight">
+      <span>Probeer in de playground</span>
+      <span aria-hidden className="transition group-hover:translate-x-1">→</span>
+    </div>
+  </motion.button>
+);
+
+const Playground = () => {
+  const [activeSlug, setActiveSlug] = useState(experiments[0]?.slug ?? '');
+  const [version, setVersion] = useState(0);
+
+  const activeExperiment = useMemo(
+    () => experiments.find((experiment) => experiment.slug === activeSlug) ?? experiments[0],
+    [activeSlug]
+  );
+
+  useEffect(() => {
+    setVersion(0);
+  }, [activeSlug]);
+
+  const ActiveExperimentComponent = activeExperiment
+    ? experimentComponents[activeExperiment.slug]
+    : undefined;
+
+  const sandboxKey = `${activeExperiment?.slug ?? 'none'}-${version}`;
+
+  return (
+    <section id="playground" className="space-y-12">
+      <SectionHeading
+        eyebrow="Playground"
+        title="Mini apps & vibe coding"
+        description="Kleine experimenten die ik bouw om ideeën uit te proberen. Klik op een kaart om direct in de sandbox te spelen en bekijk de code."
+      />
+      <div className="grid gap-10 xl:grid-cols-[minmax(0,1.1fr)_minmax(0,0.9fr)] xl:items-start">
+        <FadeIn className="order-2 grid gap-4 sm:grid-cols-2 xl:order-1">
+          {experiments.map((experiment) => (
+            <ExperimentCard
+              key={experiment.slug}
+              experiment={experiment}
+              isActive={experiment.slug === activeExperiment?.slug}
+              onSelect={() => setActiveSlug(experiment.slug)}
+            />
+          ))}
+        </FadeIn>
+        <motion.div
+          layout
+          className="order-1 flex flex-col gap-6 rounded-3xl border border-white/10 bg-gradient-to-br from-background via-background/80 to-background/40 p-6 shadow-xl xl:order-2"
+        >
+          <div className="space-y-3">
+            <p className="text-xs uppercase tracking-[0.3em] text-highlight">Live sandbox</p>
+            <h3 className="font-display text-3xl font-semibold text-foreground">{activeExperiment?.title}</h3>
+            <p className="text-sm text-muted-foreground">{activeExperiment?.description}</p>
+          </div>
+          <div className="flex flex-wrap gap-2 text-xs text-muted-foreground">
+            {activeExperiment?.stack.map((item) => (
+              <span key={item} className="rounded-full border border-white/10 px-3 py-1">
+                {item}
+              </span>
+            ))}
+          </div>
+          <div className="relative overflow-hidden rounded-2xl border border-white/10 bg-white/[0.03] p-4">
+            <AnimatePresence mode="wait">
+              <motion.div
+                key={sandboxKey}
+                initial={{ opacity: 0, y: 16 }}
+                animate={{ opacity: 1, y: 0 }}
+                exit={{ opacity: 0, y: -16 }}
+                transition={{ duration: 0.4, ease: 'easeOut' }}
+                className="min-h-[320px]"
+              >
+                {ActiveExperimentComponent ? <ActiveExperimentComponent /> : null}
+              </motion.div>
+            </AnimatePresence>
+          </div>
+          <div className="flex flex-wrap gap-3">
+            <ShinyButton onClick={() => setVersion((current) => current + 1)} className="flex-1 sm:flex-none">
+              Herstart mini app
+            </ShinyButton>
+            {activeExperiment?.github ? (
+              <ShinyButton href={activeExperiment.github} className="flex-1 sm:flex-none" variant="ghost">
+                Bekijk GitHub
+              </ShinyButton>
+            ) : null}
+          </div>
+        </motion.div>
+      </div>
+    </section>
+  );
+};
+
+export default Playground;

--- a/data/content.ts
+++ b/data/content.ts
@@ -118,6 +118,45 @@ export const projects: Project[] = [
   },
 ];
 
+export type Experiment = {
+  slug: string;
+  title: string;
+  summary: string;
+  description: string;
+  github: string;
+  stack: string[];
+};
+
+export const experiments: Experiment[] = [
+  {
+    slug: 'gradient-playground',
+    title: 'Gradient Playground',
+    summary: 'Speel met kleurcombinaties, pas de hoek aan en kopieer direct de CSS voor je eigen project.',
+    description:
+      'Een mini-tool voor visuele denkers: kies je kleuren, randomiseer een nieuwe mix of verfijn de hoek tot alles klopt. Perfect om snel een nieuw thema te voelen.',
+    github: 'https://github.com/tobiasvdorp/portfolio/blob/main/components/experiments/gradient-playground.tsx',
+    stack: ['React', 'Framer Motion', 'TailwindCSS'],
+  },
+  {
+    slug: 'lofi-focus-timer',
+    title: 'Lo-fi Focus Timer',
+    summary: 'Een pomodoro-timer met zachte gradients die automatisch tussen focus en pauze schakelt.',
+    description:
+      'Stel je ideale focus- en pauzetijden in, druk op start en laat de app je ritme bewaken. De timer schakelt automatisch door en geeft je flow visueel weer.',
+    github: 'https://github.com/tobiasvdorp/portfolio/blob/main/components/experiments/lofi-focus-timer.tsx',
+    stack: ['React Hooks', 'State Machines Light', 'TailwindCSS'],
+  },
+  {
+    slug: 'moodboard-mixer',
+    title: 'Moodboard Mixer',
+    summary: 'Kies een vibe, ontdek palettes en laat je inspireren door kleine opdrachten met emoji-verhalen.',
+    description:
+      'Met één klik wissel je tussen chill, energy of adventure moods. Elke selectie geeft je nieuwe kleurpaletten, prompts en mini-brieven voor je volgende design.',
+    github: 'https://github.com/tobiasvdorp/portfolio/blob/main/components/experiments/moodboard-mixer.tsx',
+    stack: ['React', 'Framer Motion', 'Design Systems'],
+  },
+];
+
 export type Skill = {
   name: string;
   description: string;


### PR DESCRIPTION
## Summary
- introduce a Playground section on the homepage to highlight interactive mini apps
- implement three experiment components: Gradient Playground, Lo-fi Focus Timer, and Moodboard Mixer
- surface experiment metadata and GitHub links through new content data

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d16754df18832794300a503b14cff2