### PR TITLE
Add playful mini-app playground section

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -2,6 +2,7 @@ import Hero from '@/components/sections/hero';
 import About from '@/components/sections/about';
 import Experience from '@/components/sections/experience';
 import Projects from '@/components/sections/projects';
+import Playground from '@/components/sections/playground';
 import Skills from '@/components/sections/skills';
 import Contact from '@/components/sections/contact';
 
@@ -11,6 +12,7 @@ const Page = () => (
     <About />
     <Experience />
     <Projects />
+    <Playground />
     <Skills />
     <Contact />
   </>

--- a/components/layout/site-header.tsx
+++ b/components/layout/site-header.tsx
@@ -9,6 +9,7 @@ const navLinks = [
   { href: '#about', label: 'Over mij' },
   { href: '#experience', label: 'Ervaring' },
   { href: '#projects', label: 'Projecten' },
+  { href: '#playground', label: 'Speeltuin' },
   { href: '#skills', label: 'Vaardigheden' },
   { href: '#contact', label: 'Contact' },
 ];

--- a/components/playground/gradient-groove.tsx
+++ b/components/playground/gradient-groove.tsx
@@ -1,0 +1,96 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+import { cn } from '@/lib/utils';
+
+const gradientPalettes = {
+  sunrise: {
+    label: 'Sunrise Bloom',
+    colors: ['#fb7185', '#f97316', '#38bdf8'],
+  },
+  aurora: {
+    label: 'Aurora Pulse',
+    colors: ['#22d3ee', '#6366f1', '#a855f7'],
+  },
+  neon: {
+    label: 'Neon Night',
+    colors: ['#14b8a6', '#0ea5e9', '#f472b6'],
+  },
+} as const;
+
+type PaletteKey = keyof typeof gradientPalettes;
+
+type GradientGrooveProps = {
+  className?: string;
+};
+
+const GradientGroove = ({ className }: GradientGrooveProps) => {
+  const [palette, setPalette] = useState<PaletteKey>('sunrise');
+  const [angle, setAngle] = useState(42);
+
+  const gradientStyle = useMemo(
+    () => ({
+      background: `linear-gradient(${angle}deg, ${gradientPalettes[palette].colors.join(', ')})`,
+    }),
+    [angle, palette],
+  );
+
+  return (
+    <div className={cn('flex h-full flex-col gap-4', className)}>
+      <div className="relative flex-1 overflow-hidden rounded-2xl border border-white/10 bg-black/30 p-2">
+        <div className="h-full w-full rounded-xl shadow-inner transition-all duration-500" style={gradientStyle} />
+        <div className="pointer-events-none absolute inset-0 rounded-2xl ring-1 ring-inset ring-white/20" aria-hidden />
+        <div className="pointer-events-none absolute inset-x-5 bottom-5 flex justify-between text-[0.65rem] font-semibold uppercase tracking-[0.35em] text-white/70 mix-blend-luminosity">
+          <span>{gradientPalettes[palette].label}</span>
+          <span>{angle}°</span>
+        </div>
+      </div>
+      <div className="space-y-4">
+        <div className="space-y-2">
+          <label className="flex items-center justify-between text-xs font-medium text-muted-foreground">
+            Hoek
+            <span className="font-mono text-sm text-highlight">{angle}°</span>
+          </label>
+          <input
+            type="range"
+            min={0}
+            max={360}
+            value={angle}
+            onChange={(event) => setAngle(Number(event.target.value))}
+            className="h-1 w-full cursor-pointer appearance-none rounded-full bg-white/10 accent-highlight"
+            aria-label="Gradient hoek"
+          />
+        </div>
+        <div className="space-y-2">
+          <p className="text-xs font-medium uppercase tracking-[0.3em] text-muted-foreground">Paletten</p>
+          <div className="flex flex-wrap gap-3">
+            {(Object.keys(gradientPalettes) as PaletteKey[]).map((key) => {
+              const option = gradientPalettes[key];
+
+              return (
+                <button
+                  type="button"
+                  key={key}
+                  onClick={() => setPalette(key)}
+                  className={cn(
+                    'relative h-12 w-12 overflow-hidden rounded-full border border-white/15 transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-highlight/70 focus-visible:ring-offset-2 focus-visible:ring-offset-background',
+                    palette === key ? 'ring-2 ring-highlight/70 ring-offset-2 ring-offset-background' : '',
+                  )}
+                >
+                  <span className="sr-only">{option.label}</span>
+                  <span className="flex h-full w-full">
+                    {option.colors.map((color) => (
+                      <span key={color} className="flex-1" style={{ backgroundColor: color }} />
+                    ))}
+                  </span>
+                </button>
+              );
+            })}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default GradientGroove;

--- a/components/playground/lofi-haiku.tsx
+++ b/components/playground/lofi-haiku.tsx
@@ -1,0 +1,110 @@
+'use client';
+
+import { useState } from 'react';
+import { cn } from '@/lib/utils';
+
+const moodLibrary = {
+  nacht: {
+    label: 'Midnight',
+    lines: {
+      first: ['Zachte baslijnen', 'Pixels in slow-mode', 'Neon ademtochten'],
+      second: ['zweven door de skyline', 'drijven door de stilte', 'ritmen boven asfalt'],
+      third: ['ik typ zonder haast', 'commit in maanlicht', 'focus voelt vloeibaar'],
+    },
+  },
+  ochtend: {
+    label: 'Sunrise',
+    lines: {
+      first: ['Warme koffiestoom', 'Vroege toetsenborden', 'Zonnestralen tikken'],
+      second: ['wekken mijn editor', 'bloeien in de backlog', 'vinden zachte bugs'],
+      third: ['push met frisse zin', 'ik adem refactor', 'klaar voor stand-up glow'],
+    },
+  },
+  regen: {
+    label: 'Rain Delay',
+    lines: {
+      first: ['Lo-fi regenbeat', 'Druppels syncen mee', 'Blauwe windowpane'],
+      second: ['tikken tegen ruiten', 'filteren gedachten', 'klinken als hi-hats'],
+      third: ['ik ship met rust aan', 'branch stroomt net als water', 'merge voelt als thuiskomst'],
+    },
+  },
+} as const;
+
+type MoodKey = keyof typeof moodLibrary;
+
+const pickLine = (lines: readonly string[]) => lines[Math.floor(Math.random() * lines.length)];
+
+const buildHaiku = (mood: MoodKey) => {
+  const source = moodLibrary[mood].lines;
+  return [pickLine(source.first), pickLine(source.second), pickLine(source.third)];
+};
+
+type LoFiHaikuProps = {
+  className?: string;
+};
+
+const LoFiHaiku = ({ className }: LoFiHaikuProps) => {
+  const [mood, setMood] = useState<MoodKey>('nacht');
+  const [haiku, setHaiku] = useState(() => buildHaiku('nacht'));
+
+  const switchMood = (nextMood: MoodKey) => {
+    setMood(nextMood);
+    setHaiku(buildHaiku(nextMood));
+  };
+
+  const shuffle = () => {
+    setHaiku(buildHaiku(mood));
+  };
+
+  return (
+    <div className={cn('flex h-full flex-col gap-4', className)}>
+      <div className="flex flex-1 flex-col justify-between rounded-2xl border border-white/10 bg-black/30 p-5">
+        <div className="space-y-3">
+          <p className="text-xs font-medium uppercase tracking-[0.3em] text-muted-foreground">Mood</p>
+          <div className="flex flex-wrap gap-2">
+            {(Object.keys(moodLibrary) as MoodKey[]).map((key) => (
+              <button
+                key={key}
+                type="button"
+                onClick={() => switchMood(key)}
+                className={cn(
+                  'rounded-full border border-white/15 px-3 py-1.5 text-xs font-medium text-muted-foreground transition hover:border-highlight/60 hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-highlight/70 focus-visible:ring-offset-2 focus-visible:ring-offset-background',
+                  mood === key ? 'border-highlight/70 bg-highlight/15 text-foreground' : '',
+                )}
+              >
+                {moodLibrary[key].label}
+              </button>
+            ))}
+          </div>
+        </div>
+        <div className="relative mt-4 flex flex-1 flex-col justify-between overflow-hidden rounded-xl border border-white/10 bg-black/60 p-5">
+          <div className="pointer-events-none absolute -left-16 top-1/2 h-36 w-36 -translate-y-1/2 rounded-full bg-highlight/20 blur-3xl" aria-hidden />
+          <div className="pointer-events-none absolute bottom-0 right-0 h-24 w-24 rounded-full bg-accent/20 blur-3xl" aria-hidden />
+          <ul className="relative space-y-3 font-mono text-sm leading-relaxed text-muted-foreground">
+            {haiku.map((line, index) => (
+              <li key={`${line}-${index}`} className="rounded-md bg-white/5 px-3 py-2">
+                {line}
+              </li>
+            ))}
+          </ul>
+          <div className="relative mt-4 flex items-center justify-between text-[0.7rem] uppercase tracking-[0.3em] text-muted-foreground">
+            <span>Lo-fi breathing</span>
+            <span>{moodLibrary[mood].label}</span>
+          </div>
+        </div>
+        <div className="mt-5 flex items-center justify-between text-xs text-muted-foreground">
+          <span>Nieuwe inspiratie nodig?</span>
+          <button
+            type="button"
+            onClick={shuffle}
+            className="rounded-full border border-white/15 px-3 py-1.5 font-medium transition hover:border-highlight/60 hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-highlight/70 focus-visible:ring-offset-2 focus-visible:ring-offset-background"
+          >
+            Genereer haiku
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default LoFiHaiku;

--- a/components/playground/pixel-palette.tsx
+++ b/components/playground/pixel-palette.tsx
@@ -1,0 +1,131 @@
+'use client';
+
+import { useState } from 'react';
+import { cn } from '@/lib/utils';
+
+const palette = [
+  { key: 'lagoon', label: 'Lagoon', value: '#22d3ee' },
+  { key: 'violet', label: 'Violet', value: '#a855f7' },
+  { key: 'blush', label: 'Blush', value: '#f472b6' },
+  { key: 'glow', label: 'Glow', value: '#facc15' },
+  { key: 'erase', label: 'Gum', value: 'transparent' },
+] as const;
+
+const GRID_SIZE = 36;
+const GRID_COLUMNS = 6;
+
+type PaletteValue = (typeof palette)[number]['value'];
+
+type PixelPaletteProps = {
+  className?: string;
+};
+
+const PixelPalette = ({ className }: PixelPaletteProps) => {
+  const [activeColor, setActiveColor] = useState<PaletteValue>(palette[0].value);
+  const [pixels, setPixels] = useState<string[]>(() => Array.from({ length: GRID_SIZE }, () => ''));
+  const [isDragging, setIsDragging] = useState(false);
+
+  const paintPixel = (index: number) => {
+    setPixels((prev) => {
+      const next = [...prev];
+      next[index] = activeColor === 'transparent' ? '' : activeColor;
+      return next;
+    });
+  };
+
+  const handlePointerDown = (index: number) => {
+    paintPixel(index);
+    setIsDragging(true);
+  };
+
+  const handlePointerEnter = (index: number, buttons: number) => {
+    if (buttons === 1 && isDragging) {
+      paintPixel(index);
+    }
+  };
+
+  const handlePointerUp = () => {
+    setIsDragging(false);
+  };
+
+  const resetGrid = () => {
+    setPixels(Array.from({ length: GRID_SIZE }, () => ''));
+  };
+
+  return (
+    <div className={cn('flex h-full flex-col gap-4', className)}>
+      <div
+        className="flex flex-1 flex-col gap-4 rounded-2xl border border-white/10 bg-black/30 p-4"
+        onPointerUp={handlePointerUp}
+        onPointerLeave={handlePointerUp}
+      >
+        <div
+          className="grid flex-1 grid-cols-6 gap-1 rounded-xl border border-white/5 bg-white/5 p-3"
+          style={{ gridTemplateColumns: `repeat(${GRID_COLUMNS}, minmax(0, 1fr))` }}
+        >
+          {pixels.map((color, index) => (
+            <button
+              key={index}
+              type="button"
+              aria-label={`Cel ${index + 1}`}
+              onPointerDown={(event) => {
+                event.preventDefault();
+                handlePointerDown(index);
+              }}
+              onPointerEnter={(event) => handlePointerEnter(index, event.buttons)}
+              className="group relative flex items-center justify-center rounded-[0.6rem] border border-white/10 transition hover:border-highlight/60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-highlight/70 focus-visible:ring-offset-2 focus-visible:ring-offset-background"
+            >
+              <span
+                className={cn(
+                  'absolute inset-0 rounded-[0.55rem] transition duration-150',
+                  color ? 'shadow-[inset_0_0_0_1px_rgba(255,255,255,0.18)]' : 'bg-white/10 shadow-[inset_0_0_0_1px_rgba(255,255,255,0.08)] group-hover:bg-white/15',
+                )}
+                style={color ? { backgroundColor: color } : undefined}
+              />
+            </button>
+          ))}
+        </div>
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <div className="flex flex-wrap gap-2">
+            {palette.map((option) => (
+              <button
+                key={option.key}
+                type="button"
+                onClick={() => setActiveColor(option.value)}
+                className={cn(
+                  'inline-flex items-center gap-2 rounded-full border border-white/15 px-3 py-1.5 text-xs font-medium text-muted-foreground transition hover:border-highlight/60 hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-highlight/70 focus-visible:ring-offset-2 focus-visible:ring-offset-background',
+                  activeColor === option.value ? 'border-highlight/70 bg-highlight/15 text-foreground' : '',
+                )}
+              >
+                <span
+                  className="h-3.5 w-3.5 rounded-full"
+                  style={
+                    option.value === 'transparent'
+                      ? {
+                          backgroundImage:
+                            'linear-gradient(45deg, rgba(255,255,255,0.35) 25%, transparent 25%, transparent 75%, rgba(255,255,255,0.35) 75%), linear-gradient(45deg, rgba(255,255,255,0.35) 25%, transparent 25%, transparent 75%, rgba(255,255,255,0.35) 75%)',
+                          backgroundSize: '8px 8px',
+                          backgroundPosition: '0 0, 4px 4px',
+                        }
+                      : { backgroundColor: option.value }
+                  }
+                  aria-hidden
+                />
+                {option.label}
+              </button>
+            ))}
+          </div>
+          <button
+            type="button"
+            onClick={resetGrid}
+            className="rounded-full border border-white/15 px-3 py-1.5 text-xs font-medium text-muted-foreground transition hover:border-highlight/60 hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-highlight/70 focus-visible:ring-offset-2 focus-visible:ring-offset-background"
+          >
+            Reset
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default PixelPalette;

--- a/components/sections/hero.tsx
+++ b/components/sections/hero.tsx
@@ -47,6 +47,9 @@ const Hero = () => (
         <FadeIn delay={0.4}>
           <div className="flex flex-wrap gap-3">
             <ShinyButton href="#projects">Bekijk projecten</ShinyButton>
+            <ShinyButton href="#playground" variant="ghost">
+              Speel mee
+            </ShinyButton>
             <ShinyButton href="#contact" variant="ghost">
               Laten we praten
             </ShinyButton>

--- a/components/sections/playground.tsx
+++ b/components/sections/playground.tsx
@@ -1,0 +1,67 @@
+'use client';
+
+import type { ComponentType } from 'react';
+import { motion } from 'framer-motion';
+import FadeIn from '@/components/motion/fade-in';
+import GradientGroove from '@/components/playground/gradient-groove';
+import LoFiHaiku from '@/components/playground/lofi-haiku';
+import PixelPalette from '@/components/playground/pixel-palette';
+import SectionHeading from '@/components/ui/section-heading';
+import ShinyButton from '@/components/ui/shiny-button';
+import { experiments } from '@/data/content';
+
+const experimentComponents: Record<(typeof experiments)[number]['slug'], ComponentType<{ className?: string }>> = {
+  'gradient-groove': GradientGroove,
+  'pixel-palette': PixelPalette,
+  'lofi-haiku': LoFiHaiku,
+};
+
+const Playground = () => (
+  <section id="playground" className="space-y-12">
+    <SectionHeading
+      eyebrow="Speeltuin"
+      title="Experimentele mini-apps"
+      description="Een creatieve hoek waar ik snelle ideetjes parkeer. Je kunt ze hier direct proberen en zien hoe ik speel met interactie, microcopy en animatie."
+    />
+    <FadeIn className="grid gap-6 lg:grid-cols-2">
+      {experiments.map((experiment) => {
+        const Demo = experimentComponents[experiment.slug];
+
+        return (
+          <motion.article
+            key={experiment.slug}
+            whileHover={{ y: -6 }}
+            transition={{ type: 'spring', stiffness: 200, damping: 20 }}
+            className="flex h-full flex-col gap-6 overflow-hidden rounded-3xl border border-white/10 bg-background/70 p-6 shadow-lg backdrop-blur"
+          >
+            <div className="relative h-[19rem] overflow-hidden rounded-2xl border border-white/10 bg-black/20 p-4">
+              <Demo className="h-full" />
+              <div className="pointer-events-none absolute inset-0 rounded-2xl ring-1 ring-inset ring-white/15" aria-hidden />
+            </div>
+            <div className="space-y-4">
+              <div className="space-y-2">
+                <p className="text-xs uppercase tracking-[0.3em] text-highlight">{experiment.tagline}</p>
+                <h3 className="font-display text-2xl font-semibold text-foreground">{experiment.title}</h3>
+                <p className="text-sm text-muted-foreground">{experiment.description}</p>
+              </div>
+              <div className="flex flex-wrap gap-2 text-xs text-muted-foreground">
+                {experiment.stack.map((item) => (
+                  <span key={item} className="rounded-full border border-white/10 px-3 py-1">
+                    {item}
+                  </span>
+                ))}
+              </div>
+              <div className="flex flex-wrap gap-3 pt-2">
+                <ShinyButton href={experiment.github} target="_blank" rel="noreferrer">
+                  Bekijk code
+                </ShinyButton>
+              </div>
+            </div>
+          </motion.article>
+        );
+      })}
+    </FadeIn>
+  </section>
+);
+
+export default Playground;

--- a/components/ui/shiny-button.tsx
+++ b/components/ui/shiny-button.tsx
@@ -2,6 +2,7 @@
 
 import Link from 'next/link';
 import { motion } from 'framer-motion';
+import type { HTMLAttributeAnchorTarget } from 'react';
 import { cn } from '@/lib/utils';
 
 type ShinyButtonProps = {
@@ -12,12 +13,24 @@ type ShinyButtonProps = {
   variant?: 'primary' | 'ghost';
   icon?: React.ReactNode;
   type?: 'button' | 'submit' | 'reset';
+  target?: HTMLAttributeAnchorTarget;
+  rel?: string;
 };
 
 const baseClasses =
   'group relative inline-flex items-center justify-center gap-2 overflow-hidden rounded-full px-6 py-3 text-sm font-semibold transition-colors duration-300 focus:outline-none focus-visible:ring-2 focus-visible:ring-highlight/70 focus-visible:ring-offset-2 focus-visible:ring-offset-background';
 
-const ShinyButton = ({ href, children, className, onClick, variant = 'primary', icon, type = 'button' }: ShinyButtonProps) => {
+const ShinyButton = ({
+  href,
+  children,
+  className,
+  onClick,
+  variant = 'primary',
+  icon,
+  type = 'button',
+  target,
+  rel,
+}: ShinyButtonProps) => {
   const content = (
     <span className={cn('relative z-10 flex items-center gap-2', variant === 'ghost' ? 'text-foreground' : 'text-background')}>
       {children}
@@ -25,19 +38,16 @@ const ShinyButton = ({ href, children, className, onClick, variant = 'primary', 
     </span>
   );
 
-  const sharedProps = {
-    className: cn(
-      baseClasses,
-      variant === 'primary'
-        ? 'bg-gradient-to-r from-accent via-highlight to-accent shadow-glow'
-        : 'border border-white/20 bg-white/5 hover:border-highlight/80',
-      className,
-    ),
-    onClick,
-  };
+  const classNames = cn(
+    baseClasses,
+    variant === 'primary'
+      ? 'bg-gradient-to-r from-accent via-highlight to-accent shadow-glow'
+      : 'border border-white/20 bg-white/5 hover:border-highlight/80',
+    className,
+  );
 
   return href ? (
-    <Link href={href} className={sharedProps.className} onClick={onClick}>
+    <Link href={href} className={classNames} onClick={onClick} target={target} rel={rel}>
       <motion.span
         aria-hidden
         className="absolute inset-0 rounded-full opacity-0 transition-opacity duration-300 group-hover:opacity-100"
@@ -48,7 +58,7 @@ const ShinyButton = ({ href, children, className, onClick, variant = 'primary', 
       {content}
     </Link>
   ) : (
-    <button type={type} {...sharedProps}>
+    <button type={type} className={classNames} onClick={onClick}>
       <motion.span
         aria-hidden
         className="absolute inset-0 rounded-full opacity-0 transition-opacity duration-300 group-hover:opacity-100"

--- a/data/content.ts
+++ b/data/content.ts
@@ -118,6 +118,47 @@ export const projects: Project[] = [
   },
 ];
 
+export type ExperimentSlug = 'gradient-groove' | 'pixel-palette' | 'lofi-haiku';
+
+export type Experiment = {
+  slug: ExperimentSlug;
+  title: string;
+  tagline: string;
+  description: string;
+  github: string;
+  stack: string[];
+};
+
+export const experiments: Experiment[] = [
+  {
+    slug: 'gradient-groove',
+    title: 'Gradient Groove',
+    tagline: 'Mix je eigen gloed',
+    description:
+      'Stem de vibe van je interface af met realtime gradients. Kies een kleurenpalet, draai aan de hoek en zie direct hoe de sfeer verandert.',
+    github: 'https://github.com/tobiasvdorp/portfolio/blob/main/components/playground/gradient-groove.tsx',
+    stack: ['React state', 'CSS gradients', 'Creative coding'],
+  },
+  {
+    slug: 'pixel-palette',
+    title: 'Pixel Palette',
+    tagline: 'Klik, kleur, reset',
+    description:
+      'Teken je eigen mini-pattern met een 6×6 grid. Selecteer een kleur, klik (of sleep) over de tegels en creëer iets speels in een paar seconden.',
+    github: 'https://github.com/tobiasvdorp/portfolio/blob/main/components/playground/pixel-palette.tsx',
+    stack: ['Interactieve UI', 'Tailwind compositie', 'Stateful fun'],
+  },
+  {
+    slug: 'lofi-haiku',
+    title: 'Lo-fi Haiku Bot',
+    tagline: 'Ambient tekstgenerator',
+    description:
+      'Geef een mood mee en laat de bot een korte haiku schrijven voor tijdens het coden. Perfect voor een korte ademhaling tussen commits door.',
+    github: 'https://github.com/tobiasvdorp/portfolio/blob/main/components/playground/lofi-haiku.tsx',
+    stack: ['Tekst randomisatie', 'React hooks', 'Microcopy'],
+  },
+];
+
 export type Skill = {
   name: string;
   description: string;


### PR DESCRIPTION
## Summary
- introduce a "Speeltuin" section that highlights quick experiments next to the main projects
- implement Gradient Groove, Pixel Palette, and Lo-fi Haiku interactive components with matching content entries
- refresh navigation, hero CTA, and shiny button support for external links to surface the new playground

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d16754df18832794300a503b14cff2