### PR TITLE
feat: add playground section with interactive mini apps

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -2,6 +2,7 @@ import Hero from '@/components/sections/hero';
 import About from '@/components/sections/about';
 import Experience from '@/components/sections/experience';
 import Projects from '@/components/sections/projects';
+import Playground from '@/components/sections/playground';
 import Skills from '@/components/sections/skills';
 import Contact from '@/components/sections/contact';
 
@@ -11,6 +12,7 @@ const Page = () => (
     <About />
     <Experience />
     <Projects />
+    <Playground />
     <Skills />
     <Contact />
   </>

--- a/components/playground/emoji-garden.tsx
+++ b/components/playground/emoji-garden.tsx
@@ -1,0 +1,125 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+import { motion } from 'framer-motion';
+
+type MoodKey = 'focus' | 'chill' | 'party';
+
+type EmojiSpot = {
+  id: string;
+  emoji: string;
+  top: number;
+  left: number;
+  rotation: number;
+  scale: number;
+};
+
+const moodEmoji: Record<MoodKey, string[]> = {
+  focus: ['💡', '⌨️', '🧠', '📎', '📈', '☕', '📚', '📝'],
+  chill: ['🌿', '🪴', '🌙', '💤', '☁️', '🧊', '🍵', '🫧'],
+  party: ['🎉', '🎧', '🎈', '🪩', '🎵', '🔥', '🎮', '🛼'],
+};
+
+const moodBackground: Record<MoodKey, string> = {
+  focus: 'from-[#2D2A49]/80 via-[#201F3A]/80 to-[#151430]/80',
+  chill: 'from-[#1A3C34]/80 via-[#112822]/80 to-[#0A1512]/80',
+  party: 'from-[#45123E]/80 via-[#2B0D2A]/80 to-[#150611]/80',
+};
+
+const generateSpots = (mood: MoodKey, count = 14): EmojiSpot[] =>
+  Array.from({ length: count }, (_, index) => {
+    const emojiList = moodEmoji[mood];
+    const emoji = emojiList[Math.floor(Math.random() * emojiList.length)];
+
+    return {
+      id: `${mood}-${index}-${Math.random().toString(36).slice(2, 8)}`,
+      emoji,
+      top: Math.random() * 70 + 5,
+      left: Math.random() * 70 + 5,
+      rotation: (Math.random() - 0.5) * 40,
+      scale: 0.7 + Math.random() * 0.9,
+    };
+  });
+
+const EmojiGarden = () => {
+  const [mood, setMood] = useState<MoodKey>('focus');
+  const [spots, setSpots] = useState(() => generateSpots('focus'));
+
+  const headline = useMemo(() => {
+    switch (mood) {
+      case 'chill':
+        return 'Maak ruimte om even te dromen.';
+      case 'party':
+        return 'Instant dopamine drops.';
+      default:
+        return 'Focus fuel voor je volgende idee.';
+    }
+  }, [mood]);
+
+  const refresh = (nextMood?: MoodKey) => {
+    const updatedMood = nextMood ?? mood;
+    setMood(updatedMood);
+    setSpots(generateSpots(updatedMood));
+  };
+
+  return (
+    <div className="flex h-full flex-col gap-4">
+      <div
+        className={`relative h-56 overflow-hidden rounded-2xl border border-white/10 bg-gradient-to-br ${moodBackground[mood]}`}
+      >
+        <motion.div
+          key={mood}
+          className="absolute inset-0"
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          transition={{ duration: 0.5, ease: 'easeOut' }}
+        />
+        {spots.map((spot) => (
+          <motion.span
+            key={spot.id}
+            className="absolute select-none text-3xl"
+            style={{
+              top: `${spot.top}%`,
+              left: `${spot.left}%`,
+              rotate: `${spot.rotation}deg`,
+              scale: spot.scale,
+            }}
+            initial={{ opacity: 0, scale: 0.8 }}
+            animate={{ opacity: 1, scale: spot.scale }}
+            transition={{ duration: 0.4, ease: 'easeOut' }}
+          >
+            {spot.emoji}
+          </motion.span>
+        ))}
+        <div className="absolute inset-x-0 bottom-0 bg-gradient-to-t from-background/80 via-background/40 to-transparent p-4">
+          <p className="text-sm text-muted-foreground">{headline}</p>
+        </div>
+      </div>
+      <div className="flex flex-wrap gap-2">
+        {(Object.keys(moodEmoji) as MoodKey[]).map((moodKey) => (
+          <button
+            key={moodKey}
+            type="button"
+            onClick={() => refresh(moodKey)}
+            className={`rounded-full border px-4 py-2 text-xs uppercase tracking-[0.3em] transition focus:outline-none focus-visible:ring-2 focus-visible:ring-highlight/70 focus-visible:ring-offset-2 focus-visible:ring-offset-background ${
+              mood === moodKey
+                ? 'border-highlight/60 bg-highlight/20 text-foreground'
+                : 'border-white/10 bg-white/5 text-muted-foreground hover:border-white/30'
+            }`}
+          >
+            {moodKey}
+          </button>
+        ))}
+        <button
+          type="button"
+          onClick={() => refresh()}
+          className="rounded-full border border-white/10 bg-white/5 px-4 py-2 text-xs uppercase tracking-[0.3em] text-muted-foreground transition hover:border-highlight/60 hover:text-highlight focus:outline-none focus-visible:ring-2 focus-visible:ring-highlight/70 focus-visible:ring-offset-2 focus-visible:ring-offset-background"
+        >
+          Shuffle
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default EmojiGarden;

--- a/components/playground/gradient-mixer.tsx
+++ b/components/playground/gradient-mixer.tsx
@@ -1,0 +1,122 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+import { motion } from 'framer-motion';
+
+const directions = [
+  { label: 'Diagonaal', value: '135deg' },
+  { label: 'Verticaal', value: '180deg' },
+  { label: 'Horizontaal', value: '90deg' },
+  { label: 'Radiaal', value: 'circle' },
+];
+
+const randomColor = () =>
+  `#${Math.floor(0xffffff * Math.random())
+    .toString(16)
+    .padStart(6, '0')}`;
+
+const getGradient = (direction: string, colorA: string, colorB: string) =>
+  direction === 'circle'
+    ? `radial-gradient(circle at top, ${colorA}, ${colorB})`
+    : `linear-gradient(${direction}, ${colorA}, ${colorB})`;
+
+const GradientMixer = () => {
+  const [colorA, setColorA] = useState('#6D72FF');
+  const [colorB, setColorB] = useState('#F471B5');
+  const [direction, setDirection] = useState(directions[0].value);
+  const [copied, setCopied] = useState(false);
+
+  const gradient = useMemo(() => getGradient(direction, colorA, colorB), [direction, colorA, colorB]);
+
+  const handleRandomize = () => {
+    setColorA(randomColor());
+    setColorB(randomColor());
+    setDirection(directions[Math.floor(Math.random() * directions.length)].value);
+  };
+
+  const handleCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(`background: ${gradient};`);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1600);
+    } catch (error) {
+      console.error('Kon gradient niet kopiëren', error);
+      setCopied(false);
+    }
+  };
+
+  return (
+    <div className="flex h-full flex-col gap-4">
+      <div className="space-y-4 rounded-2xl border border-white/10 bg-white/5 p-4">
+        <motion.div
+          key={`${colorA}-${colorB}-${direction}`}
+          layoutId="gradient-preview"
+          className="aspect-[4/3] w-full overflow-hidden rounded-xl border border-white/10"
+          style={{ backgroundImage: gradient }}
+          initial={{ opacity: 0, scale: 0.97 }}
+          animate={{ opacity: 1, scale: 1 }}
+          transition={{ duration: 0.4, ease: 'easeOut' }}
+        />
+        <code className="block select-all rounded-xl border border-white/10 bg-background/70 p-3 text-xs text-muted-foreground">
+          background: {gradient};
+        </code>
+      </div>
+      <div className="grid gap-3 sm:grid-cols-2">
+        <label className="flex flex-col gap-2 text-xs uppercase tracking-[0.3em] text-muted-foreground">
+          Kleur A
+          <input
+            type="color"
+            aria-label="Selecteer eerste kleur"
+            value={colorA}
+            onChange={(event) => setColorA(event.target.value)}
+            className="h-10 w-full cursor-pointer rounded-xl border border-white/10 bg-transparent"
+          />
+        </label>
+        <label className="flex flex-col gap-2 text-xs uppercase tracking-[0.3em] text-muted-foreground">
+          Kleur B
+          <input
+            type="color"
+            aria-label="Selecteer tweede kleur"
+            value={colorB}
+            onChange={(event) => setColorB(event.target.value)}
+            className="h-10 w-full cursor-pointer rounded-xl border border-white/10 bg-transparent"
+          />
+        </label>
+      </div>
+      <div className="grid gap-2 sm:grid-cols-2">
+        {directions.map((option) => (
+          <button
+            key={option.value}
+            type="button"
+            onClick={() => setDirection(option.value)}
+            className={`rounded-xl border px-4 py-3 text-sm transition focus:outline-none focus-visible:ring-2 focus-visible:ring-highlight/70 focus-visible:ring-offset-2 focus-visible:ring-offset-background ${
+              direction === option.value
+                ? 'border-highlight/60 bg-highlight/20 text-foreground'
+                : 'border-white/10 bg-white/5 text-muted-foreground hover:border-white/30'
+            }`}
+          >
+            {option.label}
+          </button>
+        ))}
+      </div>
+      <div className="flex flex-wrap gap-3">
+        <button
+          type="button"
+          onClick={handleRandomize}
+          className="rounded-full border border-white/10 bg-white/5 px-4 py-2 text-sm text-foreground transition hover:border-highlight/60 hover:text-highlight focus:outline-none focus-visible:ring-2 focus-visible:ring-highlight/70 focus-visible:ring-offset-2 focus-visible:ring-offset-background"
+        >
+          Verrassing
+        </button>
+        <button
+          type="button"
+          onClick={handleCopy}
+          className="rounded-full border border-white/10 bg-gradient-to-r from-accent via-highlight to-accent px-4 py-2 text-sm font-semibold text-background transition hover:shadow-glow focus:outline-none focus-visible:ring-2 focus-visible:ring-highlight/70 focus-visible:ring-offset-2 focus-visible:ring-offset-background"
+        >
+          {copied ? 'Gekopieerd!' : 'Kopieer CSS'}
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default GradientMixer;

--- a/components/playground/pixel-sketch.tsx
+++ b/components/playground/pixel-sketch.tsx
@@ -1,0 +1,105 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+
+const GRID_SIZE = 10;
+
+const palettes = [
+  {
+    name: 'Sunset',
+    colors: ['#FDBA74', '#FB7185', '#C084FC', '#A855F7'],
+  },
+  {
+    name: 'Lagoon',
+    colors: ['#5EEAD4', '#38BDF8', '#818CF8', '#22D3EE'],
+  },
+  {
+    name: 'Solar',
+    colors: ['#FACC15', '#FB923C', '#F97316', '#FDE68A'],
+  },
+];
+
+const createBlankPixels = () => Array.from({ length: GRID_SIZE * GRID_SIZE }, () => 'transparent');
+
+const PixelSketch = () => {
+  const [paletteIndex, setPaletteIndex] = useState(0);
+  const [selectedColor, setSelectedColor] = useState(palettes[0].colors[0]);
+  const [pixels, setPixels] = useState<string[]>(() => createBlankPixels());
+
+  const palette = palettes[paletteIndex];
+
+  const paintPixel = (index: number) => {
+    setPixels((prev) => {
+      const next = [...prev];
+      next[index] = selectedColor;
+      return next;
+    });
+  };
+
+  const cyclePalette = () => {
+    setPaletteIndex((prev) => {
+      const nextIndex = (prev + 1) % palettes.length;
+      setSelectedColor(palettes[nextIndex].colors[0]);
+      return nextIndex;
+    });
+  };
+
+  const clearCanvas = () => {
+    setPixels(createBlankPixels());
+  };
+
+  const paintedCount = useMemo(() => pixels.filter((color) => color !== 'transparent').length, [pixels]);
+
+  return (
+    <div className="flex h-full flex-col gap-4">
+      <div className="flex items-center justify-between rounded-2xl border border-white/10 bg-white/5 px-4 py-3 text-xs uppercase tracking-[0.3em] text-muted-foreground">
+        <span>{palette.name}</span>
+        <span>{paintedCount} / {GRID_SIZE * GRID_SIZE} pixels</span>
+      </div>
+      <div className="rounded-2xl border border-white/10 bg-white/5 p-3">
+        <div className="grid grid-cols-10 gap-1">
+          {pixels.map((color, index) => (
+            <button
+              key={index}
+              type="button"
+              onClick={() => paintPixel(index)}
+              aria-label={`Kleur pixel ${index + 1}`}
+              className="aspect-square w-full rounded-md border border-white/5 transition hover:border-highlight/60 focus:outline-none focus-visible:ring-2 focus-visible:ring-highlight/70 focus-visible:ring-offset-2 focus-visible:ring-offset-background"
+              style={{ background: color === 'transparent' ? 'transparent' : color }}
+            />
+          ))}
+        </div>
+      </div>
+      <div className="flex flex-wrap items-center gap-3">
+        {palette.colors.map((color) => (
+          <button
+            key={color}
+            type="button"
+            onClick={() => setSelectedColor(color)}
+            className={`h-10 w-10 rounded-full border-2 transition focus:outline-none focus-visible:ring-2 focus-visible:ring-highlight/70 focus-visible:ring-offset-2 focus-visible:ring-offset-background ${
+              selectedColor === color ? 'border-highlight shadow-glow' : 'border-white/10'
+            }`}
+            style={{ background: color }}
+            aria-label={`Gebruik kleur ${color}`}
+          />
+        ))}
+        <button
+          type="button"
+          onClick={cyclePalette}
+          className="rounded-full border border-white/10 bg-white/5 px-4 py-2 text-xs uppercase tracking-[0.3em] text-muted-foreground transition hover:border-highlight/60 hover:text-highlight focus:outline-none focus-visible:ring-2 focus-visible:ring-highlight/70 focus-visible:ring-offset-2 focus-visible:ring-offset-background"
+        >
+          Nieuw palet
+        </button>
+        <button
+          type="button"
+          onClick={clearCanvas}
+          className="rounded-full border border-white/10 bg-gradient-to-r from-accent via-highlight to-accent px-4 py-2 text-xs uppercase tracking-[0.3em] font-semibold text-background transition hover:shadow-glow focus:outline-none focus-visible:ring-2 focus-visible:ring-highlight/70 focus-visible:ring-offset-2 focus-visible:ring-offset-background"
+        >
+          Wis canvas
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default PixelSketch;

--- a/components/sections/playground.tsx
+++ b/components/sections/playground.tsx
@@ -1,0 +1,93 @@
+'use client';
+
+import { type ComponentType } from 'react';
+import { motion } from 'framer-motion';
+import FadeIn from '@/components/motion/fade-in';
+import GradientMixer from '@/components/playground/gradient-mixer';
+import EmojiGarden from '@/components/playground/emoji-garden';
+import PixelSketch from '@/components/playground/pixel-sketch';
+import SectionHeading from '@/components/ui/section-heading';
+import ShinyButton from '@/components/ui/shiny-button';
+
+const repoBase = 'https://github.com/tobiasvandorp/portfolio/tree/main/components/playground';
+
+type Experiment = {
+  title: string;
+  description: string;
+  tags: string[];
+  github: string;
+  Component: ComponentType;
+};
+
+const experiments: Experiment[] = [
+  {
+    title: 'Gradient Mixer',
+    description:
+      'Speel met twee kleuren en de richting van de gradient totdat je de perfecte achtergrond voor je volgende project hebt. Kopieer de CSS direct naar je clipboard.',
+    tags: ['CSS', 'Design tooling'],
+    github: `${repoBase}/gradient-mixer.tsx`,
+    Component: GradientMixer,
+  },
+  {
+    title: 'Emoji Garden',
+    description:
+      'Kies de vibe, shuffle en vul het canvas met emoji-confetti. Een lichte UX-tool om energie, focus of feestje aan je ontwerp toe te voegen.',
+    tags: ['Micro-interactions', 'Creativity'],
+    github: `${repoBase}/emoji-garden.tsx`,
+    Component: EmojiGarden,
+  },
+  {
+    title: 'Pixel Sketch',
+    description:
+      'Een mini-pixelart studio. Schakel tussen paletten, schilder losse pixels en reset wanneer je ready bent voor een nieuw idee.',
+    tags: ['State management', 'Playful UI'],
+    github: `${repoBase}/pixel-sketch.tsx`,
+    Component: PixelSketch,
+  },
+];
+
+const Playground = () => (
+  <section id="playground" className="space-y-12">
+    <SectionHeading
+      eyebrow="Playground"
+      title="Mini-appjes voor de fun"
+      description="Kleine experimenten die ik tussendoor bouw. Je kunt ze hier meteen uitproberen en de code terugvinden."
+    />
+    <FadeIn className="grid gap-6 xl:grid-cols-3">
+      {experiments.map(({ title, description, tags, github, Component }) => (
+        <motion.article
+          key={title}
+          whileHover={{ y: -6 }}
+          transition={{ duration: 0.4, ease: 'easeOut' }}
+          className="flex h-full flex-col gap-6 overflow-hidden rounded-3xl border border-white/10 bg-background/70 p-6 shadow-lg"
+        >
+          <div className="space-y-3">
+            <div className="flex items-center gap-2 text-xs uppercase tracking-[0.3em] text-highlight">
+              <span className="h-1 w-1 rounded-full bg-highlight" aria-hidden />
+              Vibe code
+            </div>
+            <h3 className="font-display text-xl font-semibold text-foreground">{title}</h3>
+            <p className="text-sm text-muted-foreground">{description}</p>
+            <div className="flex flex-wrap gap-2 text-xs text-muted-foreground">
+              {tags.map((tag) => (
+                <span key={tag} className="rounded-full border border-white/10 px-3 py-1">
+                  {tag}
+                </span>
+              ))}
+            </div>
+          </div>
+          <div className="flex-1">
+            <Component />
+          </div>
+          <div className="pt-2">
+            <ShinyButton href={github} className="w-full justify-center" variant="ghost">
+              Bekijk op GitHub
+            </ShinyButton>
+          </div>
+        </motion.article>
+      ))}
+    </FadeIn>
+  </section>
+);
+
+export default Playground;


### PR DESCRIPTION
## Summary
- add a Playground section to highlight interactive vibe-code experiments alongside the main projects
- build Gradient Mixer, Emoji Garden, and Pixel Sketch mini-app components with live previews
- wire the new section into the homepage and surface GitHub links for each experiment

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d16754df18832794300a503b14cff2